### PR TITLE
Route based code-splitting

### DIFF
--- a/src/client/src/components/App.tsx
+++ b/src/client/src/components/App.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, {Suspense, lazy} from 'react';
 import {Footer} from './Footer';
 import {Provider} from 'mobx-react';
 import {createStores} from '../stores/CreateStore';
-import {Project} from './Project/Project';
-import {Login} from './Login/Login';
 import {MainMenu} from "./MainMenu";
 import {BrowserRouter as Router, Route, Switch,} from "react-router-dom";
-import {Projects} from "./Projects/Projects";
-import {Work} from "./Work/Work";
-import {Collaborators} from "./Collaborators/Collaborators";
-import {Changes} from "./Changes/Changes";
-import {ChangeDetail} from "./Changes/ChangeDetail";
 
+const Login = lazy(() => import('./Login/Login'));
+const Projects = lazy(() => import('./Projects/Projects'));
+const Project = lazy(() => import('./Project/Project'));
+const Work = lazy(() => import('./Work/Work'));
+const Collaborators = lazy(() => import('./Collaborators/Collaborators'));
+const Changes = lazy(() => import('./Changes/Changes'));
+const ChangeDetail = lazy(() => import('./Changes/ChangeDetail'));
 
 const stores = createStores()
 
@@ -20,18 +20,18 @@ function App() {
         <Provider {...stores}>
             <Router>
                 <MainMenu/>
-
-                <Switch>
-                    <Route exact path="/" component={Login}/>
-                    <Route exact path="/projects" component={Projects}/>
-                    <Route path="/changes/:id" component={ChangeDetail}/>
-                    <Route path="/projects/:id" component={Project}/>
-                    <Route path="/collaborators/:id" component={Collaborators}/>
-                    <Route path="/:projectId/works/:workId/changes" component={Changes}/>
-                    <Route path="/:projectId/works/:id" component={Work}/>
-                    <Route path="*" component={Login}/>
-                </Switch>
-
+                <Suspense fallback={<div>Loading...</div>}>
+                    <Switch>
+                        <Route exact path="/" component={Login}/>
+                        <Route exact path="/projects" component={Projects}/>
+                        <Route path="/changes/:id" component={ChangeDetail}/>
+                        <Route path="/projects/:id" component={Project}/>
+                        <Route path="/collaborators/:id" component={Collaborators}/>
+                        <Route path="/:projectId/works/:workId/changes" component={Changes}/>
+                        <Route path="/:projectId/works/:id" component={Work}/>
+                        <Route path="*" component={Login}/>
+                    </Switch>
+                </Suspense>
                 <Footer/>
             </Router>
         </Provider>

--- a/src/client/src/components/Changes/ChangeDetail.tsx
+++ b/src/client/src/components/Changes/ChangeDetail.tsx
@@ -29,3 +29,5 @@ export const ChangeDetail = inject(Stores.CHANGE_STORE)(observer((props: IChange
         </div>
     )
 }))
+
+export default ChangeDetail;

--- a/src/client/src/components/Changes/Changes.tsx
+++ b/src/client/src/components/Changes/Changes.tsx
@@ -29,3 +29,5 @@ export const Changes = inject(Stores.CHANGE_STORE)(observer((props: IChangesProp
         </div>
     )
 }))
+
+export default Changes;

--- a/src/client/src/components/Collaborators/Collaborators.tsx
+++ b/src/client/src/components/Collaborators/Collaborators.tsx
@@ -15,3 +15,5 @@ export function Collaborators() {
     )
 }
 
+export default Collaborators
+

--- a/src/client/src/components/Login/Login.tsx
+++ b/src/client/src/components/Login/Login.tsx
@@ -35,3 +35,4 @@ export const Login = inject(Stores.USER_STORE)(observer((props: ILoginProps) => 
     )
 }))
 
+export default Login

--- a/src/client/src/components/Project/Project.tsx
+++ b/src/client/src/components/Project/Project.tsx
@@ -28,3 +28,5 @@ export const Project = inject(Stores.USER_STORE)(observer((props: IProjectProps)
         </div>
     )
 }));
+
+export default Project

--- a/src/client/src/components/Projects/Projects.tsx
+++ b/src/client/src/components/Projects/Projects.tsx
@@ -28,3 +28,5 @@ export const Projects = inject(Stores.USER_STORE)(observer((props: IProjectsProp
         </div>
     )
 }));
+
+export default Projects

--- a/src/client/src/components/Work/Work.tsx
+++ b/src/client/src/components/Work/Work.tsx
@@ -30,3 +30,5 @@ export const Work = inject(Stores.USER_STORE)(observer((props: IWorkProps) => {
         </div>
     )
 }));
+
+export default Work


### PR DESCRIPTION
Make each route small bundle of our app that can be loaded lazily.

Route based code-splitting was implemented as illustrated in docs:
https://reactjs.org/docs/code-splitting.html#route-based-code-splitting

Motivation: 
Imagine big company using our product.
HR people use Collaborators page.
Project managers use Projects page.
Their submanagers could use Works page.
And individual workers can mark their changes in Changes page.

Changes page for HR is useless, so don't load it, only if their explicitly request.
Works page is useless for project managers, they have submanagers for this purpose, and so on...
